### PR TITLE
Add simple tests around 'important' Message verification handlers

### DIFF
--- a/game/src/main/org/apollo/game/message/handler/ObjectActionVerificationHandler.java
+++ b/game/src/main/org/apollo/game/message/handler/ObjectActionVerificationHandler.java
@@ -26,7 +26,7 @@ public final class ObjectActionVerificationHandler extends MessageHandler<Object
 	 * @param objects The list of objects.
 	 * @return {@code true} if the list does contain the object with the specified id, otherwise {@code false}.
 	 */
-	private static boolean containsObject(int id, Set<GameObject> objects) {
+	public static boolean containsObject(int id, Set<GameObject> objects) {
 		return objects.stream().anyMatch(object -> object.getId() == id);
 	}
 

--- a/game/src/test/org/apollo/game/message/handler/ChatMessageHandlerTest.java
+++ b/game/src/test/org/apollo/game/message/handler/ChatMessageHandlerTest.java
@@ -1,0 +1,34 @@
+package org.apollo.game.message.handler;
+
+import org.apollo.game.message.impl.ChatMessage;
+import org.apollo.game.model.World;
+import org.apollo.game.model.entity.Player;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.*;
+import static org.powermock.api.mockito.PowerMockito.*;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Player.class})
+public class ChatMessageHandlerTest {
+
+	private final World world = new World();
+	private final ChatMessageHandler chatMessageHandler = new ChatMessageHandler(world);
+
+	@Test
+	public void testTerminatedIfMuted() throws Exception {
+		Player player = PowerMockito.mock(Player.class);
+
+		when(player.isMuted()).thenReturn(true);
+
+		ChatMessage chatMessage = new ChatMessage("Test", "Test".getBytes(), 0, 0);
+		chatMessageHandler.handle(player, chatMessage);
+
+		assertTrue("ChatMessageHandler: player can send messages when muted", chatMessage.terminated());
+	}
+}

--- a/game/src/test/org/apollo/game/message/handler/ItemOnItemVerificationHandlerTest.java
+++ b/game/src/test/org/apollo/game/message/handler/ItemOnItemVerificationHandlerTest.java
@@ -21,7 +21,10 @@ import static org.junit.Assert.assertTrue;
 @PrepareForTest({Player.class, ItemDefinition.class})
 public class ItemOnItemVerificationHandlerTest {
 
-	private ItemOnItemVerificationHandler verificationHandler = new ItemOnItemVerificationHandler(new World());
+	private World world = new World();
+
+	private ItemOnItemVerificationHandler itemOnItemVerificationHandler = new ItemOnItemVerificationHandler(world);
+	private ItemVerificationHandler itemVerificationHandler = new ItemVerificationHandler(world);
 
 	@BeforeClass
 	public static void setupTestItemDefinitions() {
@@ -40,7 +43,8 @@ public class ItemOnItemVerificationHandlerTest {
 		ItemOnItemMessage itemOnItemMessage = new ItemOnItemMessage(BankConstants.SIDEBAR_INVENTORY_ID, 500, 1,
 				BankConstants.SIDEBAR_INVENTORY_ID, 4151, 1);
 
-		verificationHandler.handle(player, itemOnItemMessage);
+		itemVerificationHandler.handle(player, itemOnItemMessage);
+		itemOnItemVerificationHandler.handle(player, itemOnItemMessage);
 
 		assertTrue("ItemOnItemVerificationHandler: failed checking source item / slot exists", itemOnItemMessage.terminated());
 	}

--- a/game/src/test/org/apollo/game/message/handler/ItemOnItemVerificationHandlerTest.java
+++ b/game/src/test/org/apollo/game/message/handler/ItemOnItemVerificationHandlerTest.java
@@ -24,29 +24,11 @@ public class ItemOnItemVerificationHandlerTest {
 	private World world = new World();
 
 	private ItemOnItemVerificationHandler itemOnItemVerificationHandler = new ItemOnItemVerificationHandler(world);
-	private ItemVerificationHandler itemVerificationHandler = new ItemVerificationHandler(world);
 
 	@Before
 	public void setupTestItemDefinitions() {
 		mockStatic(ItemDefinition.class);
 		when(ItemDefinition.lookup(4151)).thenReturn(new ItemDefinition(4151));
-	}
-
-	@Test
-	public void testTerminateWithNoSourceItem() throws Exception {
-		Player player = mock(Player.class);
-		Inventory inventory = new Inventory(28);
-		inventory.set(1, new Item(4151, 1));
-
-		when(player.getInventory()).thenReturn(inventory);
-
-		ItemOnItemMessage itemOnItemMessage = new ItemOnItemMessage(BankConstants.SIDEBAR_INVENTORY_ID, 500, 1,
-				BankConstants.SIDEBAR_INVENTORY_ID, 4151, 1);
-
-		itemVerificationHandler.handle(player, itemOnItemMessage);
-		itemOnItemVerificationHandler.handle(player, itemOnItemMessage);
-
-		assertTrue("ItemOnItemVerificationHandler: failed terminating message with invalid source item", itemOnItemMessage.terminated());
 	}
 
 	@Test
@@ -60,7 +42,6 @@ public class ItemOnItemVerificationHandlerTest {
 		ItemOnItemMessage itemOnItemMessage = new ItemOnItemMessage(BankConstants.SIDEBAR_INVENTORY_ID, 4151, 1,
 				BankConstants.SIDEBAR_INVENTORY_ID, 4152, 2);
 
-		itemVerificationHandler.handle(player, itemOnItemMessage);
 		itemOnItemVerificationHandler.handle(player, itemOnItemMessage);
 
 		assertTrue("ItemOnItemVerificationHandler: failed terminating message with invalid target item", itemOnItemMessage.terminated());

--- a/game/src/test/org/apollo/game/message/handler/ItemOnItemVerificationHandlerTest.java
+++ b/game/src/test/org/apollo/game/message/handler/ItemOnItemVerificationHandlerTest.java
@@ -7,6 +7,7 @@ import org.apollo.game.model.World;
 import org.apollo.game.model.entity.Player;
 import org.apollo.game.model.inter.bank.BankConstants;
 import org.apollo.game.model.inv.Inventory;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,8 +26,8 @@ public class ItemOnItemVerificationHandlerTest {
 	private ItemOnItemVerificationHandler itemOnItemVerificationHandler = new ItemOnItemVerificationHandler(world);
 	private ItemVerificationHandler itemVerificationHandler = new ItemVerificationHandler(world);
 
-	@BeforeClass
-	public static void setupTestItemDefinitions() {
+	@Before
+	public void setupTestItemDefinitions() {
 		mockStatic(ItemDefinition.class);
 		when(ItemDefinition.lookup(4151)).thenReturn(new ItemDefinition(4151));
 	}

--- a/game/src/test/org/apollo/game/message/handler/ItemOnItemVerificationHandlerTest.java
+++ b/game/src/test/org/apollo/game/message/handler/ItemOnItemVerificationHandlerTest.java
@@ -1,0 +1,47 @@
+package org.apollo.game.message.handler;
+
+import org.apollo.cache.def.ItemDefinition;
+import org.apollo.game.message.impl.ItemOnItemMessage;
+import org.apollo.game.model.Item;
+import org.apollo.game.model.World;
+import org.apollo.game.model.entity.Player;
+import org.apollo.game.model.inter.bank.BankConstants;
+import org.apollo.game.model.inv.Inventory;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Player.class, ItemDefinition.class})
+public class ItemOnItemVerificationHandlerTest {
+
+	private ItemOnItemVerificationHandler verificationHandler = new ItemOnItemVerificationHandler(new World());
+
+	@BeforeClass
+	public static void setupTestItemDefinitions() {
+		PowerMockito.mockStatic(ItemDefinition.class);
+		Mockito.when(ItemDefinition.lookup(4151)).thenReturn(new ItemDefinition(4151));
+	}
+
+	@Test
+	public void testTerminateWithNoSourceItem() throws Exception {
+		Player player = PowerMockito.mock(Player.class);
+		Inventory inventory = new Inventory(28);
+		inventory.set(1, new Item(4151, 1));
+
+		Mockito.when(player.getInventory()).thenReturn(inventory);
+
+		ItemOnItemMessage itemOnItemMessage = new ItemOnItemMessage(BankConstants.SIDEBAR_INVENTORY_ID, 500, 1,
+				BankConstants.SIDEBAR_INVENTORY_ID, 4151, 1);
+
+		verificationHandler.handle(player, itemOnItemMessage);
+
+		assertTrue("ItemOnItemVerificationHandler: failed checking source item / slot exists", itemOnItemMessage.terminated());
+	}
+}

--- a/game/src/test/org/apollo/game/message/handler/ItemOnItemVerificationHandlerTest.java
+++ b/game/src/test/org/apollo/game/message/handler/ItemOnItemVerificationHandlerTest.java
@@ -10,12 +10,11 @@ import org.apollo.game.model.inv.Inventory;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
+import static org.powermock.api.mockito.PowerMockito.*;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Player.class, ItemDefinition.class})
@@ -28,17 +27,17 @@ public class ItemOnItemVerificationHandlerTest {
 
 	@BeforeClass
 	public static void setupTestItemDefinitions() {
-		PowerMockito.mockStatic(ItemDefinition.class);
-		Mockito.when(ItemDefinition.lookup(4151)).thenReturn(new ItemDefinition(4151));
+		mockStatic(ItemDefinition.class);
+		when(ItemDefinition.lookup(4151)).thenReturn(new ItemDefinition(4151));
 	}
 
 	@Test
 	public void testTerminateWithNoSourceItem() throws Exception {
-		Player player = PowerMockito.mock(Player.class);
+		Player player = mock(Player.class);
 		Inventory inventory = new Inventory(28);
 		inventory.set(1, new Item(4151, 1));
 
-		Mockito.when(player.getInventory()).thenReturn(inventory);
+		when(player.getInventory()).thenReturn(inventory);
 
 		ItemOnItemMessage itemOnItemMessage = new ItemOnItemMessage(BankConstants.SIDEBAR_INVENTORY_ID, 500, 1,
 				BankConstants.SIDEBAR_INVENTORY_ID, 4151, 1);
@@ -51,11 +50,11 @@ public class ItemOnItemVerificationHandlerTest {
 
 	@Test
 	public void testTerminateWithNoTargetItem() throws Exception {
-		Player player = PowerMockito.mock(Player.class);
+		Player player = mock(Player.class);
 		Inventory inventory = new Inventory(28);
 		inventory.set(1, new Item(4151, 1));
 
-		Mockito.when(player.getInventory()).thenReturn(inventory);
+		when(player.getInventory()).thenReturn(inventory);
 
 		ItemOnItemMessage itemOnItemMessage = new ItemOnItemMessage(BankConstants.SIDEBAR_INVENTORY_ID, 4151, 1,
 				BankConstants.SIDEBAR_INVENTORY_ID, 4152, 2);

--- a/game/src/test/org/apollo/game/message/handler/ItemOnItemVerificationHandlerTest.java
+++ b/game/src/test/org/apollo/game/message/handler/ItemOnItemVerificationHandlerTest.java
@@ -46,6 +46,23 @@ public class ItemOnItemVerificationHandlerTest {
 		itemVerificationHandler.handle(player, itemOnItemMessage);
 		itemOnItemVerificationHandler.handle(player, itemOnItemMessage);
 
-		assertTrue("ItemOnItemVerificationHandler: failed checking source item / slot exists", itemOnItemMessage.terminated());
+		assertTrue("ItemOnItemVerificationHandler: failed terminating message with invalid source item", itemOnItemMessage.terminated());
+	}
+
+	@Test
+	public void testTerminateWithNoTargetItem() throws Exception {
+		Player player = PowerMockito.mock(Player.class);
+		Inventory inventory = new Inventory(28);
+		inventory.set(1, new Item(4151, 1));
+
+		Mockito.when(player.getInventory()).thenReturn(inventory);
+
+		ItemOnItemMessage itemOnItemMessage = new ItemOnItemMessage(BankConstants.SIDEBAR_INVENTORY_ID, 4151, 1,
+				BankConstants.SIDEBAR_INVENTORY_ID, 4152, 2);
+
+		itemVerificationHandler.handle(player, itemOnItemMessage);
+		itemOnItemVerificationHandler.handle(player, itemOnItemMessage);
+
+		assertTrue("ItemOnItemVerificationHandler: failed terminating message with invalid target item", itemOnItemMessage.terminated());
 	}
 }

--- a/game/src/test/org/apollo/game/message/handler/ItemOnObjectVerificationHandlerTest.java
+++ b/game/src/test/org/apollo/game/message/handler/ItemOnObjectVerificationHandlerTest.java
@@ -1,0 +1,135 @@
+package org.apollo.game.message.handler;
+
+import org.apollo.cache.def.ItemDefinition;
+import org.apollo.cache.def.ObjectDefinition;
+import org.apollo.game.message.impl.ItemOnObjectMessage;
+import org.apollo.game.model.Item;
+import org.apollo.game.model.Position;
+import org.apollo.game.model.World;
+import org.apollo.game.model.area.Region;
+import org.apollo.game.model.area.RegionRepository;
+import org.apollo.game.model.entity.Entity;
+import org.apollo.game.model.entity.EntityType;
+import org.apollo.game.model.entity.Player;
+import org.apollo.game.model.entity.obj.StaticGameObject;
+import org.apollo.game.model.inter.bank.BankConstants;
+import org.apollo.game.model.inv.Inventory;
+import org.apollo.game.model.inv.SynchronizationInventoryListener;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertTrue;
+import static org.powermock.api.mockito.PowerMockito.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Player.class, World.class, Region.class, RegionRepository.class, ObjectDefinition.class,
+		ItemDefinition.class})
+public class ItemOnObjectVerificationHandlerTest {
+
+	@Before
+	public void setupTestItemDefinitions() {
+		mockStatic(ItemDefinition.class);
+		when(ItemDefinition.lookup(4151)).thenReturn(new ItemDefinition(4151));
+
+		mockStatic(ObjectDefinition.class);
+		when(ObjectDefinition.count()).thenReturn(2);
+	}
+
+
+	@Test
+	public void testTerminateIfInvalidItem() throws Exception {
+		Position playerPosition = new Position(3200, 3200);
+		Position objectPosition = new Position(3200, 3216);
+
+		World world = mock(World.class);
+		Region region = mock(Region.class);
+		RegionRepository regionRepository = mock(RegionRepository.class);
+		Player player = mock(Player.class);
+
+		Set<Entity> entitySet = new HashSet<>();
+		entitySet.add(new StaticGameObject(world, 4151, objectPosition, 0, 0));
+		Inventory inventory = new Inventory(28);
+
+		when(player.getInventory()).thenReturn(inventory);
+		when(world.getRegionRepository()).thenReturn(regionRepository);
+		when(regionRepository.fromPosition(objectPosition)).thenReturn(region);
+		when(player.getPosition()).thenReturn(playerPosition);
+		when(region.getEntities(objectPosition, EntityType.STATIC_OBJECT, EntityType.DYNAMIC_OBJECT))
+				.thenReturn(entitySet);
+
+		ItemOnObjectMessage itemOnObjectMessage = new ItemOnObjectMessage(SynchronizationInventoryListener.INVENTORY_ID, 4151, 1,
+				1, objectPosition.getX(), objectPosition.getY());
+		ItemOnObjectVerificationHandler itemOnObjectVerificationHandler = new ItemOnObjectVerificationHandler(world);
+
+		itemOnObjectVerificationHandler.handle(player, itemOnObjectMessage);
+
+		assertTrue("ObjectVerificationHandler: message not terminated valid item given!", itemOnObjectMessage.terminated());
+	}
+
+	@Test
+	public void testTerminateIfInvalidSlot() throws Exception {
+		Position playerPosition = new Position(3200, 3200);
+		Position objectPosition = new Position(3200, 3200);
+
+		World world = mock(World.class);
+		Region region = mock(Region.class);
+		RegionRepository regionRepository = mock(RegionRepository.class);
+		Player player = mock(Player.class);
+
+		Set<Entity> entitySet = new HashSet<>();
+		entitySet.add(new StaticGameObject(world, 4151, objectPosition, 0, 0));
+		Inventory inventory = new Inventory(28);
+
+		when(player.getInventory()).thenReturn(inventory);
+		when(world.getRegionRepository()).thenReturn(regionRepository);
+		when(regionRepository.fromPosition(objectPosition)).thenReturn(region);
+		when(player.getPosition()).thenReturn(playerPosition);
+		when(region.getEntities(objectPosition, EntityType.STATIC_OBJECT, EntityType.DYNAMIC_OBJECT))
+				.thenReturn(entitySet);
+
+		ItemOnObjectMessage itemOnObjectMessage = new ItemOnObjectMessage(SynchronizationInventoryListener.INVENTORY_ID, 4151, 30,
+				1, objectPosition.getX(), objectPosition.getY());
+		ItemOnObjectVerificationHandler itemOnObjectVerificationHandler = new ItemOnObjectVerificationHandler(world);
+
+		itemOnObjectVerificationHandler.handle(player, itemOnObjectMessage);
+
+		assertTrue("ObjectVerificationHandler: message not terminated when no valid slot given!", itemOnObjectMessage.terminated());
+	}
+
+	@Test
+	public void testTerminateIfObjectOutOfRange() throws Exception {
+		Position playerPosition = new Position(3200, 3200);
+		Position objectPosition = new Position(3200, 3200);
+
+		World world = mock(World.class);
+		Region region = mock(Region.class);
+		RegionRepository regionRepository = mock(RegionRepository.class);
+		Player player = mock(Player.class);
+
+		Set<Entity> entitySet = new HashSet<>();
+		entitySet.add(new StaticGameObject(world, 4151, objectPosition, 0, 0));
+		Inventory inventory = new Inventory(28);
+		inventory.set(1, new Item(4151, 1));
+
+		when(player.getInventory()).thenReturn(inventory);
+		when(world.getRegionRepository()).thenReturn(regionRepository);
+		when(regionRepository.fromPosition(objectPosition)).thenReturn(region);
+		when(player.getPosition()).thenReturn(playerPosition);
+		when(region.getEntities(objectPosition, EntityType.STATIC_OBJECT, EntityType.DYNAMIC_OBJECT))
+				.thenReturn(entitySet);
+
+		ItemOnObjectMessage itemOnObjectMessage = new ItemOnObjectMessage(SynchronizationInventoryListener.INVENTORY_ID, 4151, 1,
+				1, objectPosition.getX(), objectPosition.getY());
+		ItemOnObjectVerificationHandler itemOnObjectVerificationHandler = new ItemOnObjectVerificationHandler(world);
+
+		itemOnObjectVerificationHandler.handle(player, itemOnObjectMessage);
+
+		assertTrue("ObjectVerificationHandler: message not terminated when object out of range!", itemOnObjectMessage.terminated());
+	}
+}

--- a/game/src/test/org/apollo/game/message/handler/ObjectActionVerificationHandlerTest.java
+++ b/game/src/test/org/apollo/game/message/handler/ObjectActionVerificationHandlerTest.java
@@ -1,0 +1,91 @@
+package org.apollo.game.message.handler;
+
+import org.apollo.cache.def.ItemDefinition;
+import org.apollo.cache.def.ObjectDefinition;
+import org.apollo.game.message.impl.ObjectActionMessage;
+import org.apollo.game.model.Position;
+import org.apollo.game.model.World;
+import org.apollo.game.model.area.Region;
+import org.apollo.game.model.area.RegionRepository;
+import org.apollo.game.model.entity.Entity;
+import org.apollo.game.model.entity.EntityType;
+import org.apollo.game.model.entity.Player;
+import org.apollo.game.model.entity.obj.StaticGameObject;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({World.class, Player.class, ObjectDefinition.class, RegionRepository.class, Region.class})
+public class ObjectActionVerificationHandlerTest {
+
+	@BeforeClass
+	public static void setupTestObjectDefinitions() {
+		mockStatic(ObjectDefinition.class);
+		when(ObjectDefinition.count()).thenReturn(4152);
+	}
+
+	@Test
+	public void testTerminateIfOutOfRange() throws Exception {
+		Position playerPosition = new Position(3200, 3200);
+		Position objectPosition = new Position(3200, 3216);
+
+		World world = mock(World.class);
+		Region region = mock(Region.class);
+		RegionRepository regionRepository = mock(RegionRepository.class);
+		Player player = mock(Player.class);
+
+		Set<Entity> entitySet = new HashSet<>();
+		entitySet.add(new StaticGameObject(world, 4151, objectPosition, 0, 0));
+
+		when(world.getRegionRepository()).thenReturn(regionRepository);
+		when(regionRepository.fromPosition(objectPosition)).thenReturn(region);
+		when(player.getPosition()).thenReturn(playerPosition);
+		when(region.getEntities(objectPosition, EntityType.STATIC_OBJECT, EntityType.DYNAMIC_OBJECT))
+				.thenReturn(entitySet);
+
+		ObjectActionMessage objectActionMessage = new ObjectActionMessage(1, 4151, objectPosition);
+		ObjectActionVerificationHandler objectActionVerificationHandler = new ObjectActionVerificationHandler(world);
+
+		objectActionVerificationHandler.handle(player, objectActionMessage);
+
+		assertTrue("ObjectVerificationHandler: message not terminated when out of range!", objectActionMessage.terminated());
+	}
+
+	@Test
+
+	public void testTerminateIfNoObject() throws Exception {
+		Position playerPosition = new Position(3200, 3200);
+		Position objectPosition = new Position(3200, 3201);
+
+		World world = mock(World.class);
+		Region region = mock(Region.class);
+		RegionRepository regionRepository = mock(RegionRepository.class);
+		Player player = mock(Player.class);
+
+		Set<Entity> entitySet = new HashSet<>();
+
+		when(world.getRegionRepository()).thenReturn(regionRepository);
+		when(regionRepository.fromPosition(objectPosition)).thenReturn(region);
+		when(player.getPosition()).thenReturn(playerPosition);
+		when(region.getEntities(objectPosition, EntityType.STATIC_OBJECT, EntityType.DYNAMIC_OBJECT))
+				.thenReturn(entitySet);
+
+		ObjectActionMessage objectActionMessage = new ObjectActionMessage(1, 4151, objectPosition);
+		ObjectActionVerificationHandler objectActionVerificationHandler = new ObjectActionVerificationHandler(world);
+
+		objectActionVerificationHandler.handle(player, objectActionMessage);
+
+		assertTrue("ObjectVerificationHandler: message not terminated when no object exists!", objectActionMessage.terminated());
+	}
+}

--- a/game/src/test/org/apollo/game/message/handler/ObjectActionVerificationHandlerTest.java
+++ b/game/src/test/org/apollo/game/message/handler/ObjectActionVerificationHandlerTest.java
@@ -11,6 +11,7 @@ import org.apollo.game.model.entity.Entity;
 import org.apollo.game.model.entity.EntityType;
 import org.apollo.game.model.entity.Player;
 import org.apollo.game.model.entity.obj.StaticGameObject;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,8 +30,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @PrepareForTest({World.class, Player.class, ObjectDefinition.class, RegionRepository.class, Region.class})
 public class ObjectActionVerificationHandlerTest {
 
-	@BeforeClass
-	public static void setupTestObjectDefinitions() {
+	@Before
+	public void setupTestObjectDefinitions() {
 		mockStatic(ObjectDefinition.class);
 		when(ObjectDefinition.count()).thenReturn(4152);
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,18 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>1.6.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>1.6.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
       <version>1.10</version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,18 +45,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>1.6.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>1.6.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
       <version>1.10</version>
@@ -97,6 +85,21 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>1.6.2</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>1.6.2</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## Testing the MessageHandler implementations

This introduces a couple of tests which verify that several of the MessageHandler implementations (Chat, ItemOnItem, ObjectAction) terminate messages appropriately. These few examples outline how tests like this could be written.

One issue I did find was that there is no verification that an object exists (as far as I can tell) in an ItemOnObject message. I'll write a few more tests and update any failing code as needed.

## Notes

Admittedly mocking isn't necessarily needed here because we aren't accessing the file system or any system resources, but setting up all of these classes with all of their dependencies would be mayhem. 

## New Dependencies

* Mockito - A library for mocking classes in tests
* PowerMock - A mocking library to work around final classes and static methods