### PR TITLE
Add .editorconfig file to override IDE defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+trim_trailing_whitespace = true
+insert_final_newline = false
+
+[*.java]
+indent_style=tab
+tab_width=4
+
+[*.rb]
+indent_style=space
+indent_size=2

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
+.*
+
 !.gitignore
 !.rubocop.yml
+!.editorconfig
 
-.*
 *~
 *.class
 *.iml
@@ -10,3 +12,4 @@
 /data/savedGames
 /lib/
 */target/
+


### PR DESCRIPTION
Quite a simple addition, which is compatible with most editors (IDEA, Vim, Eclipse, NetBeans, Sublime, Notepad++, so on...). This shouldn't be an issue for most editors since they will adapt the the current source code but people will always have their own settings.

The [EditorConfig](http://editorconfig.org/) provided will override the IDE defaults for indentation in Java and Ruby source code. It overrides the defaults for indentation and trailing whitespace, by making sure no trailing whitespace is kept (or at least highlighting it) and setting the indent size for Java to tabs with a width of 4, and spaces with a width of 2 for Ruby.

Additionally it makes sure no final newline is kept (had a look, this seems to be the norm across Apollo).