### PR TITLE
Handle errors thrown by SynchronousDecoder tasks

### DIFF
--- a/game/src/main/org/apollo/game/fs/decoder/SynchronousDecoder.java
+++ b/game/src/main/org/apollo/game/fs/decoder/SynchronousDecoder.java
@@ -4,9 +4,9 @@ import org.apollo.util.ThreadUtil;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * A composite decoder that executes each child in parallel.
@@ -44,11 +44,21 @@ public final class SynchronousDecoder {
 	 * Starts this SynchronousDecoder.
 	 *
 	 * @throws InterruptedException If a decoder is still running after {@link #TIMEOUT} ms.
+	 * @throws SynchronousDecoderException If a decoder failed to complete successfully.
 	 */
-	public void block() throws InterruptedException {
-		runnables.forEach(executor::submit);
-		executor.shutdown();
-		executor.awaitTermination(TIMEOUT, TimeUnit.MILLISECONDS);
-	}
+	public void block() throws InterruptedException, SynchronousDecoderException {
+		List<Future> futureList = runnables.stream()
+			.map(executor::submit)
+			.collect(toList());
 
+		executor.awaitTermination(TIMEOUT, TimeUnit.MILLISECONDS);
+
+		for (Future future : futureList) {
+			try {
+				future.get();
+			} catch (ExecutionException e) {
+				throw new SynchronousDecoderException("Unable to run all decoder tasks", e.getCause());
+			}
+		}
+	}
 }

--- a/game/src/main/org/apollo/game/fs/decoder/SynchronousDecoder.java
+++ b/game/src/main/org/apollo/game/fs/decoder/SynchronousDecoder.java
@@ -51,6 +51,7 @@ public final class SynchronousDecoder {
 			.map(executor::submit)
 			.collect(toList());
 
+		executor.shutdown();
 		executor.awaitTermination(TIMEOUT, TimeUnit.MILLISECONDS);
 
 		for (Future future : futureList) {

--- a/game/src/main/org/apollo/game/fs/decoder/SynchronousDecoderException.java
+++ b/game/src/main/org/apollo/game/fs/decoder/SynchronousDecoderException.java
@@ -1,0 +1,16 @@
+package org.apollo.game.fs.decoder;
+
+/**
+ * An exception thrown when a {@link SynchronousDecoder} fails to complete successfully.
+ *
+ * @author garyttierney
+ */
+public class SynchronousDecoderException extends Exception {
+    public SynchronousDecoderException(String message) {
+        super(message);
+    }
+
+    public SynchronousDecoderException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
Check for errors thrown during execution of any SynchronousDecoder tasks, and
rethrow any ExecutionExceptions as SynchronousDecoderExceptions.

Adds to the `executor` calls by using the Futures returned from the result of executor::submit and calling get() on them to cause any exceptions thrown to bubble up as ExecutionExceptions (see: [Future#get](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Future.html#get--), in particular `ExecutionException - if the computation threw an exception`).

Currently, neither of the calls to `executor.shutdown()` or `executor.awaitTermination(...)` will cause an exception thrown by one of the tasks to be rethrown and will allow the server to continue cleanly as if no error occurred.