### PR TITLE
Fix short circuit logic in ItemDefinitionDecoder

### DIFF
--- a/cache/src/main/org/apollo/cache/decoder/ItemDefinitionDecoder.java
+++ b/cache/src/main/org/apollo/cache/decoder/ItemDefinitionDecoder.java
@@ -108,7 +108,7 @@ public final class ItemDefinitionDecoder implements Runnable {
 					buffer.getShort();
 					buffer.getShort();
 				}
-			} else if (opcode == 78 || opcode == 79 || opcode >= 90 || opcode <= 93 || opcode == 95) {
+			} else if (opcode == 78 || opcode == 79 || (opcode >= 90 && opcode <= 93) || opcode == 95) {
 				buffer.getShort();
 			} else if (opcode == 97) {
 				definition.setNoteInfoId(buffer.getShort() & 0xFFFF);


### PR DESCRIPTION
* Replaces an OR, with what should have been an AND while decoding
  unused item definition info.