### PR TITLE
Correct the height levels of steps in a path

### DIFF
--- a/game/src/main/org/apollo/game/model/entity/WalkingQueue.java
+++ b/game/src/main/org/apollo/game/model/entity/WalkingQueue.java
@@ -122,6 +122,7 @@ public final class WalkingQueue {
 	 */
 	public void pulse() {
 		Position position = mob.getPosition();
+		int height = position.getHeight();
 
 		Direction firstDirection = Direction.NONE;
 		Direction secondDirection = Direction.NONE;
@@ -130,14 +131,14 @@ public final class WalkingQueue {
 		if (next != null) {
 			previousPoints.add(next);
 			firstDirection = Direction.between(position, next);
-			position = next;
+			position = new Position(next.getX(), next.getY(), height);
 
 			if (running) {
 				next = points.poll();
 				if (next != null) {
 					previousPoints.add(next);
 					secondDirection = Direction.between(position, next);
-					position = next;
+					position = new Position(next.getX(), next.getY(), height);
 				}
 			}
 		}


### PR DESCRIPTION
Makes sure that the steps in a path sent for a "Player Walk" message are
on the same height level as the player that sent them beforethey are
added to the walking queue.

Fixes #109.

This is a bit of a crude fix, I think. Could this be better done in whatever handles steps in the WalkingQueue? cc @Major- 