### PR TITLE
Fix actions continuing when equipping 2h swords

### DIFF
--- a/game/src/main/org/apollo/game/message/handler/EquipItemHandler.java
+++ b/game/src/main/org/apollo/game/message/handler/EquipItemHandler.java
@@ -94,6 +94,8 @@ public final class EquipItemHandler extends MessageHandler<ItemOptionMessage> {
 			if (weapon != null) {
 				inventory.add(weapon);
 			}
+
+			player.stopAction();
 			return;
 		}
 


### PR DESCRIPTION
Fixes a peculiar bug related to equipping 2h swords. To reproduce,
start an action, and while doing that action equip a 2h sword. It
won't stop the action. The expected result is to stop the action
and require a restart.

Reproduce: http://webm.host/f0cbc/vid.webm