### PR TITLE
Game packets encoded with MTB Encoder instead of MTM Encoder.

### DIFF
--- a/net/src/main/org/apollo/net/codec/game/GamePacketEncoder.java
+++ b/net/src/main/org/apollo/net/codec/game/GamePacketEncoder.java
@@ -1,21 +1,17 @@
 package org.apollo.net.codec.game;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
-
-import java.util.List;
-
+import io.netty.handler.codec.MessageToByteEncoder;
 import org.apollo.net.meta.PacketType;
 import org.apollo.util.security.IsaacRandom;
 
 /**
- * A {@link MessageToMessageEncoder} which encodes in-game packets.
+ * A {@link MessageToByteEncoder} which encodes in-game packets.
  *
  * @author Graham
  */
-public final class GamePacketEncoder extends MessageToMessageEncoder<GamePacket> {
+public final class GamePacketEncoder extends MessageToByteEncoder<GamePacket> {
 
 	/**
 	 * The random number generator.
@@ -32,32 +28,26 @@ public final class GamePacketEncoder extends MessageToMessageEncoder<GamePacket>
 	}
 
 	@Override
-	protected void encode(ChannelHandlerContext ctx, GamePacket packet, List<Object> out) throws Exception {
+	protected void encode(ChannelHandlerContext ctx, GamePacket packet, ByteBuf out) throws Exception {
 		PacketType type = packet.getType();
-		int headerLength = 1;
 		int payloadLength = packet.getLength();
 		if (type == PacketType.VARIABLE_BYTE) {
-			headerLength++;
 			if (payloadLength >= 256) {
 				throw new Exception("Payload too long for variable byte packet.");
 			}
 		} else if (type == PacketType.VARIABLE_SHORT) {
-			headerLength += 2;
 			if (payloadLength >= 65_536) {
 				throw new Exception("Payload too long for variable short packet.");
 			}
 		}
 
-		ByteBuf buffer = Unpooled.buffer(headerLength + payloadLength);
-		buffer.writeByte(packet.getOpcode() + random.nextInt() & 0xFF);
+		out.writeByte(packet.getOpcode() + random.nextInt() & 0xFF);
 		if (type == PacketType.VARIABLE_BYTE) {
-			buffer.writeByte(payloadLength);
+			out.writeByte(payloadLength);
 		} else if (type == PacketType.VARIABLE_SHORT) {
-			buffer.writeShort(payloadLength);
+			out.writeShort(payloadLength);
 		}
-		buffer.writeBytes(packet.getPayload());
-
-		out.add(buffer);
+		out.writeBytes(packet.getPayload());
 	}
 
 }

--- a/net/src/main/org/apollo/net/codec/login/LoginEncoder.java
+++ b/net/src/main/org/apollo/net/codec/login/LoginEncoder.java
@@ -2,16 +2,14 @@ package org.apollo.net.codec.login;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToMessageEncoder;
-
-import java.util.List;
+import io.netty.handler.codec.MessageToByteEncoder;
 
 /**
- * A {@link MessageToMessageEncoder} which encodes login response messages.
+ * A {@link MessageToByteEncoder} which encodes login response messages.
  *
  * @author Graham
  */
-public final class LoginEncoder extends MessageToMessageEncoder<LoginResponse> {
+public final class LoginEncoder extends MessageToByteEncoder<LoginResponse> {
 
 	/**
 	 * Creates the login encoder.
@@ -21,16 +19,13 @@ public final class LoginEncoder extends MessageToMessageEncoder<LoginResponse> {
 	}
 
 	@Override
-	protected void encode(ChannelHandlerContext ctx, LoginResponse response, List<Object> out) {
-		ByteBuf buffer = ctx.alloc().buffer(3);
-		buffer.writeByte(response.getStatus());
+	protected void encode(ChannelHandlerContext ctx, LoginResponse response, ByteBuf out) {
+		out.writeByte(response.getStatus());
 
 		if (response.getStatus() == LoginConstants.STATUS_OK) {
-			buffer.writeByte(response.getRights());
-			buffer.writeByte(response.isFlagged() ? 1 : 0);
+			out.writeByte(response.getRights());
+			out.writeByte(response.isFlagged() ? 1 : 0);
 		}
-
-		out.add(buffer);
 	}
 
 }


### PR DESCRIPTION
Very small PR that encodes game packets with `MessageToByteEncoder` instead of `MessageToMessageEncoder`. Unless there was a specific reason why Graham used the latter?