### PR TITLE
Fix Teleporting Spam Clicking

### DIFF
--- a/data/plugins/skill/magic/magic.rb
+++ b/data/plugins/skill/magic/magic.rb
@@ -26,7 +26,7 @@ class SpellAction < Action
   attr_reader :spell, :pulses
 
   def initialize(mob, spell)
-    super(0, true, mob)
+    super(1, true, mob)
     @spell = spell
     @pulses = 0
   end
@@ -81,7 +81,7 @@ class SpellAction < Action
   end
 
   def equals(other)
-    get_class == other.get_class && @spell == other.spell
+    get_class == other.get_class
   end
 
 end


### PR DESCRIPTION
* You can no longer spam click teleport
* You can no longer override a new spell while performing a current one

Due to not knowing how git works I had to make a new pr