### PR TITLE
Fixes #204 - corrected spelling of octet

### DIFF
--- a/net/src/main/org/apollo/net/update/HttpRequestWorker.java
+++ b/net/src/main/org/apollo/net/update/HttpRequestWorker.java
@@ -107,7 +107,7 @@ public final class HttpRequestWorker extends RequestWorker<HttpRequest, Resource
 			return "text/plain";
 		}
 
-		return "application/octect-stream";
+		return "application/octet-stream";
 	}
 
 	@Override


### PR DESCRIPTION
The spelling has been rectified as specified in the issue description.