### PR TITLE
remove an useless condition

### DIFF
--- a/cache/src/main/org/apollo/cache/decoder/NpcDefinitionDecoder.java
+++ b/cache/src/main/org/apollo/cache/decoder/NpcDefinitionDecoder.java
@@ -132,7 +132,6 @@ public final class NpcDefinitionDecoder implements Runnable {
 				int count = buffer.get() & 0xFF;
 				int[] morphisms = new int[count + 1];
 				Arrays.setAll(morphisms, index -> wrap(buffer.getShort()));
-			} else if (opcode == 107) {
 			}
 		}
 	}


### PR DESCRIPTION
Hello,
I removed a useless condition.
What do you think about transforming the method with a switch case (for all the case with an equality and "opcode >= 30 && opcode < 40" and "opcode >= 90 && opcode <= 92"  in default case)  ?