### PR TITLE
add catch exception in EquipmentUpdater

### DIFF
--- a/cache/src/main/org/apollo/cache/tools/EquipmentUpdater.java
+++ b/cache/src/main/org/apollo/cache/tools/EquipmentUpdater.java
@@ -26,7 +26,7 @@ public final class EquipmentUpdater {
 	 * @param args The command line arguments.
 	 * @throws Exception If an error occurs.
 	 */
-	public static void main(String[] args) throws Exception {
+	public static void main(String[] args) {
 		Preconditions.checkArgument(args.length == 1, "Usage:\njava -cp ... org.apollo.tools.EquipmentUpdater [release].");
 		String release = args[0];
 
@@ -55,6 +55,8 @@ public final class EquipmentUpdater {
 					os.writeByte(getMagicRequirement(definition));
 				}
 			}
+		} catch (Exception e) {
+			e.printStackTrace();
 		}
 	}
 


### PR DESCRIPTION
Hello,
We see a try without catch.
We think it's better if we add a catch, because the program will not crash.