### PR TITLE
Fix Several Magic Issues

### DIFF
--- a/data/plugins/skill/magic/alchemy.rb
+++ b/data/plugins/skill/magic/alchemy.rb
@@ -37,7 +37,6 @@ class AlchemyAction < ItemSpellAction
     if @pulses == 0
       mob.play_animation(@spell.animation)
       mob.play_graphic(@spell.graphic)
-      mob.send(DISPLAY_SPELLBOOK)
 
       inventory = mob.inventory
       gold = (item.definition.value * @spell.multiplier)

--- a/data/plugins/skill/magic/convert.rb
+++ b/data/plugins/skill/magic/convert.rb
@@ -84,5 +84,5 @@ def convert(button, level, elements, experience, reward)
   CONVERT_SPELLS[button] = ConvertSpell.new(level, elements, experience, reward)
 end
 
-convert 1159, 15, { EARTH => 2, WATER => 2, NATURE => 1 }, 25, 1963 # Bones to bananas
+convert 1159, 15, { NATURE => 1, WATER => 2, EARTH => 2 }, 25, 1963 # Bones to bananas
 # convert 15877, 60, { NATURE => 2, WATER => 4, EARTH => 4 }, 35.5, 6883 # Bones to peaches

--- a/data/plugins/skill/magic/enchant.rb
+++ b/data/plugins/skill/magic/enchant.rb
@@ -8,7 +8,7 @@ ENCHANT_SPELLS = {}
 ENCHANT_ITEMS = {}
 
 RING_GFX = Graphic.new(238, 0, 100)
-RING_ANIM = Animation.new(931) 
+RING_ANIM = Animation.new(931)
 
 LOW_NECK_GFX = Graphic.new(114, 0, 100)
 LOW_NECK_ANIM = Animation.new(719)
@@ -52,10 +52,9 @@ class EnchantAction < ItemSpellAction
     if @pulses == 0
       mob.play_animation(@spell.animation)
       mob.play_graphic(@spell.graphic)
-      mob.send(DISPLAY_SPELLBOOK)
 
       mob.inventory.set(@slot, @reward)
-      mob.skill_set.add_experience(MAGIC_SKILL_ID, @spell.experience)
+      mob.skill_set.add_experience(Skill::MAGIC, @spell.experience)
 
       set_delay(@spell.delay)
     elsif @pulses == 1
@@ -73,12 +72,12 @@ def enchant(button, level, elements, item, animation, graphic, delay, experience
   ENCHANT_ITEMS[item] = reward
 end
 
-SAPPHIRE_ELEMENTS = { WATER => 1, COSMIC => 1 }
-EMERALD_ELEMENTS  = { AIR => 1, COSMIC => 1 }
-RUBY_ELEMENTS     = { FIRE => 5, COSMIC => 1 }
-DIAMOND_ELEMENTS  = { EARTH => 10, COSMIC => 1 }
-DSTONE_ELEMENTS   = { WATER => 15, EARTH => 15, COSMIC => 1 }
-ONYX_ELEMENTS     = { EARTH => 20, FIRE => 20, COSMIC => 1 }
+SAPPHIRE_ELEMENTS = { COSMIC => 1, WATER => 1 }
+EMERALD_ELEMENTS  = { COSMIC => 1, AIR => 1 }
+RUBY_ELEMENTS     = { COSMIC => 1, FIRE => 5 }
+DIAMOND_ELEMENTS  = { COSMIC => 1, EARTH => 10 }
+DSTONE_ELEMENTS   = { COSMIC => 1, EARTH => 15, WATER => 15 }
+ONYX_ELEMENTS     = { COSMIC => 1, FIRE => 20, EARTH => 20 }
 
 # Sapphire
 enchant 1155, 7, SAPPHIRE_ELEMENTS, 1637, RING_ANIM, RING_GFX, 2, 17.5, 2550 # Ring

--- a/data/plugins/skill/magic/magic.rb
+++ b/data/plugins/skill/magic/magic.rb
@@ -46,7 +46,10 @@ class SpellAction < Action
         stop
         return false
       end
-      process_elements
+      unless process_elements
+        stop
+        return
+      end
     end
     execute_action
     @pulses += 1
@@ -81,7 +84,7 @@ class SpellAction < Action
   end
 
   def equals(other)
-    get_class == other.get_class && @spell == other.spell
+    get_class == other.get_class
   end
 
 end
@@ -100,6 +103,8 @@ class ItemSpellAction < SpellAction
   def execute
     if @pulses == 0
       id = @item.id
+
+      mob.send(DISPLAY_SPELLBOOK)
 
       # TODO: There has to be a better way to do this.
       @spell.elements.each do |element, amount|

--- a/data/plugins/skill/magic/teleport.rb
+++ b/data/plugins/skill/magic/teleport.rb
@@ -11,8 +11,7 @@ java_import 'org.apollo.game.model.entity.Skill'
 TELEPORT_SPELLS = {}
 
 MODERN_TELE_ANIM = Animation.new(714)
-MODERN_TELE_END_ANIM = Animation.new(715)
-MODERN_TELE_GRAPHIC = Graphic.new(308, 15, 100)
+MODERN_TELE_GRAPHIC = Graphic.new(111, 5, 100)
 
 ANCIENT_TELE_END_GRAPHIC = Graphic.new(455)
 ANCIENT_TELE_ANIM = Animation.new(1979)
@@ -45,12 +44,10 @@ class TeleportingAction < SpellAction
   def execute_modern
     if @pulses == 0
       mob.play_animation(MODERN_TELE_ANIM)
-    elsif @pulses == 1
       mob.play_graphic(MODERN_TELE_GRAPHIC)
-      set_delay(1)
-    elsif @pulses == 2
+    elsif @pulses == 3
       mob.stop_graphic
-      mob.play_animation(MODERN_TELE_END_ANIM)
+      mob.stopAnimation
       mob.teleport(@spell.destination)
       mob.skill_set.add_experience(Skill::MAGIC, @spell.experience)
       stop
@@ -83,14 +80,14 @@ def ancient_tele(*args)
 end
 
 # Modern teleports
-tele 1_164, 25, { FIRE => 1, AIR => 3, LAW => 1 }, 3213, 3424, 35, 'Varrock'
-tele 1_167, 31, { EARTH => 1, AIR => 3, LAW => 1 }, 3222, 3219, 41, 'Lumbridge'
-tele 1_170, 37, { WATER => 1, AIR => 3, LAW => 1 }, 2965, 3379, 47, 'Falador'
-tele 1_174, 45, { AIR => 5, LAW => 1 }, 2757, 3478, 55.5, 'Camelot'
-tele 1_540, 51, { WATER => 2, LAW => 2 }, 2662, 3306, 61, 'Ardougne'
-tele 1_541, 58, { EARTH => 2, LAW => 2 }, 2549, 3114, 68, 'the Watchtower'
-tele 7_455, 61, { FIRE => 2, LAW => 2 }, 2871, 3590, 68, 'Trollheim'
-tele 18_470, 64, { FIRE => 2, WATER => 2, LAW => 2, Element.new([1963], nil, 'Banana') => 1 },
+tele 1_164, 25, { LAW => 1, AIR => 3, FIRE => 1 }, 3213, 3424, 35, 'Varrock'
+tele 1_167, 31, { LAW => 1, AIR => 3, EARTH => 1 }, 3222, 3219, 41, 'Lumbridge'
+tele 1_170, 37, { LAW => 1, AIR => 3, WATER => 1 }, 2965, 3379, 47, 'Falador'
+tele 1_174, 45, { LAW => 1, AIR => 5 }, 2757, 3478, 55.5, 'Camelot'
+tele 1_540, 51, { LAW => 2, WATER => 2 }, 2662, 3306, 61, 'Ardougne'
+tele 1_541, 58, { LAW => 2, EARTH => 2 }, 2549, 3114, 68, 'the Watchtower'
+tele 7_455, 61, { LAW => 2, FIRE => 2 }, 2871, 3590, 68, 'Trollheim'
+tele 18_470, 64, { Element.new([1963], nil, 'Banana') => 1, LAW => 2, WATER => 2, FIRE => 2 },
      2_754, 2_785, 76, 'Ape Atoll'
 
 # Ancient teleports

--- a/data/plugins/skill/magic/teleport.rb
+++ b/data/plugins/skill/magic/teleport.rb
@@ -47,7 +47,7 @@ class TeleportingAction < SpellAction
       mob.play_graphic(MODERN_TELE_GRAPHIC)
     elsif @pulses == 3
       mob.stop_graphic
-      mob.stopAnimation
+      mob.stop_animation
       mob.teleport(@spell.destination)
       mob.skill_set.add_experience(Skill::MAGIC, @spell.experience)
       stop


### PR DESCRIPTION
* Fix OverRide Magic Spells
* Fix Process Element check
* Reordered the rune amounts so now it can be read clearly of how runescape has it by (primary, elemental)
* Changed MAGIC_SKILL_ID for add exp to Skill::Magic in enchant so you now gain exp instead of an error message
* For spells like alching they should always bring you back to your spell book even if you do not have the level requirment or the runes.