### PR TITLE
improve the performance of the segment_text method in dialogue.rb

### DIFF
--- a/data/plugins/dialogue/dialogue.rb
+++ b/data/plugins/dialogue/dialogue.rb
@@ -324,17 +324,19 @@ class Dialogue
     maximum_width = (@type == :text) ? MAXIMUM_LINE_WIDTH : MAXIMUM_MEDIA_LINE_WIDTH
 
     segments = []
+    n = text.length
     index = 0; width = 0; space = 0
 
-    while index < text.length
+    while index < n
       char = text[index]
       space = index if char == ' '
       width += get_width(char)
       index += 1
 
       if (width >= maximum_width)
-        segments << text[0..space]
+        segments << text[0..(space - 1)]
         text = text[(space + 1)..-1]
+        n = text.length
         width = index = space = 0
       end
     end


### PR DESCRIPTION
Hello,

I saw that we calculated the size of text for each iteration, which is very costly in computation time. Now I use a variable that contains this size and is refreshed only when we change the text.

Also I deleted the character at the end of the line because it is useless.