### PR TITLE
Simplify the method getIndefiniteArticle

### DIFF
--- a/util/src/main/org/apollo/util/LanguageUtil.java
+++ b/util/src/main/org/apollo/util/LanguageUtil.java
@@ -16,10 +16,8 @@ public final class LanguageUtil {
 	 */
 	public static String getIndefiniteArticle(String string) {
 		char first = Character.toLowerCase(string.charAt(0));
-		if (allUpperCase(string)) {
-			if (first == 'f' || first == 'l' | first == 'm' || first == 'n' || first == 's') {
+		if (allUpperCase(string) && (first == 'f' || first == 'l' || first == 'm' || first == 'n' || first == 's')) {
 				return "an";
-			}
 		}
 
 		boolean vowel = first == 'a' || first == 'e' || first == 'i' || first == 'o' || first == 'u';


### PR DESCRIPTION
Hello,
I found a redundant if in the method getIndefiniteArticle in the class LanguageUtil, so i remove it.
But something seems weird in the second if, the one i remove. Why is there just one '|' between first == 'l' and first == 'm' ?
Thanks.