### PR TITLE
Remove cast to int from long

### DIFF
--- a/game/src/main/org/apollo/game/release/r317/ItemOnItemMessageDecoder.java
+++ b/game/src/main/org/apollo/game/release/r317/ItemOnItemMessageDecoder.java
@@ -19,14 +19,14 @@ public final class ItemOnItemMessageDecoder extends MessageDecoder<ItemOnItemMes
 	public ItemOnItemMessage decode(GamePacket packet) {
 		GamePacketReader reader = new GamePacketReader(packet);
 
-		int targetSlot = (int) reader.getUnsigned(DataType.SHORT);
-		int usedSlot = (int) reader.getUnsigned(DataType.SHORT, DataTransformation.ADD);
+		int targetSlot = Math.toIntExact(reader.getUnsigned(DataType.SHORT));
+		int usedSlot = Math.toIntExact(reader.getUnsigned(DataType.SHORT, DataTransformation.ADD));
 
-		int targetId = (int) reader.getSigned(DataType.SHORT, DataOrder.LITTLE, DataTransformation.ADD);
-		int targetInterface = (int) reader.getUnsigned(DataType.SHORT);
+		int targetId = Math.toIntExact(reader.getSigned(DataType.SHORT, DataOrder.LITTLE, DataTransformation.ADD));
+		int targetInterface = Math.toIntExact(reader.getUnsigned(DataType.SHORT));
 
-		int usedId = (int) reader.getSigned(DataType.SHORT, DataOrder.LITTLE);
-		int usedInterface = (int) reader.getUnsigned(DataType.SHORT);
+		int usedId = Math.toIntExact(reader.getSigned(DataType.SHORT, DataOrder.LITTLE));
+		int usedInterface = Math.toIntExact(reader.getUnsigned(DataType.SHORT));
 
 		return new ItemOnItemMessage(usedInterface, usedId, usedSlot, targetInterface, targetId, targetSlot);
 	}


### PR DESCRIPTION
Hello,

I saw a cast to int from long. And long is bigger than int, so the cast doesn't work always.
For example :
```
public static void main(String[] args) {
	int test1 = (int) Long.MAX_VALUE;
	System.out.println("with (int) : " + test1);

	int test2 = Math.toIntExact(Long.MAX_VALUE);
	System.out.println("with Math.toIntExact : " + test2);
}
```
```
with (int) : -1
Exception in thread "main" java.lang.ArithmeticException: integer overflow
	at java.lang.Math.toIntExact(Math.java:1011)
	at org.apollo.game.release.r317.ItemOnItemMessageDecoder.main(ItemOnItemMessageDecoder.java:38)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:144)

Process finished with exit code 1
```

This was coded in 2013-2014. Since Java 8, there are a new method : [Math.toIntExact](http://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#toIntExact-long-). If the long overflows an int, an exception is thrown. You can catch this exception to manage this case, if you want. So I think it's safer and cleaner.

Also, if you agree with that, I can correct the problem in the others classes.

Thanks.