### PR TITLE
Remove useless if

### DIFF
--- a/net/src/main/org/apollo/net/codec/game/GamePacketEncoder.java
+++ b/net/src/main/org/apollo/net/codec/game/GamePacketEncoder.java
@@ -31,14 +31,11 @@ public final class GamePacketEncoder extends MessageToByteEncoder<GamePacket> {
 	protected void encode(ChannelHandlerContext ctx, GamePacket packet, ByteBuf out) throws Exception {
 		PacketType type = packet.getType();
 		int payloadLength = packet.getLength();
-		if (type == PacketType.VARIABLE_BYTE) {
-			if (payloadLength >= 256) {
-				throw new Exception("Payload too long for variable byte packet.");
-			}
-		} else if (type == PacketType.VARIABLE_SHORT) {
-			if (payloadLength >= 65_536) {
-				throw new Exception("Payload too long for variable short packet.");
-			}
+		
+		if (type == PacketType.VARIABLE_BYTE && payloadLength >= 256) {
+			throw new Exception("Payload too long for variable byte packet.");
+		} else if (type == PacketType.VARIABLE_SHORT && payloadLength >= 65_536) {
+			throw new Exception("Payload too long for variable short packet.");
 		}
 
 		out.writeByte(packet.getOpcode() + random.nextInt() & 0xFF);


### PR DESCRIPTION
Hello, 
I saw two useless if in `GamePacketEncoder` in the package `org.apollo.net.codec.game`.
I decided to remove these two if to make the method *encode* more simpler.
I also pass a line (line 34) to make it more readable.
Thanks.
