### PR TITLE
Turn player to objects when interacting with them

### DIFF
--- a/data/plugins/entity/interaction/object.rb
+++ b/data/plugins/entity/interaction/object.rb
@@ -1,0 +1,6 @@
+# Catch all object actions and turn the player to
+# the position of the object
+
+on :message, :object_action do |player, message|
+  player.turn_to message.position
+end

--- a/data/plugins/entity/interaction/plugin.xml
+++ b/data/plugins/entity/interaction/plugin.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<plugin>
+    <id>entity-interaction</id>
+    <version>0.1</version>
+    <name>Entity Interaction</name>
+    <description>Adds support for generic entity interactions (facing objects when using an action, etc).</description>
+    <authors>
+        <author>garyttierney</author>
+    </authors>
+    <scripts>
+        <script>object.rb</script>
+    </scripts>
+</plugin>


### PR DESCRIPTION
Resolves #271 I believe. I don't think the issue there is that objects are larger than 1 tile, but that some plugins are handling turning to objects themselves. 
