### PR TITLE
Template method on DefinitionDecoder

### DIFF
--- a/cache/src/main/org/apollo/cache/decoder/DefinitionDecoder.java
+++ b/cache/src/main/org/apollo/cache/decoder/DefinitionDecoder.java
@@ -1,0 +1,67 @@
+package org.apollo.cache.decoder;
+
+import org.apollo.cache.IndexedFileSystem;
+import org.apollo.cache.archive.Archive;
+import org.apollo.cache.def.Definition;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Decodes data from the {@code obj.dat} file into {@link Definition}s.
+ *
+ * @author AymericDu
+ */
+public abstract class DefinitionDecoder<D extends Definition> implements Runnable {
+
+	/**
+	 * The  IndexedFileSystem.
+	 */
+	private final IndexedFileSystem fs;
+
+	/**
+	 * Creates the DefinitionDecoder.
+	 *
+	 * @param fs The {@link IndexedFileSystem}.
+	 */
+	public DefinitionDecoder(IndexedFileSystem fs) {
+		this.fs = fs;
+	}
+
+	@Override
+	public void run() {
+		try {
+			Archive config = fs.getArchive(0, 2);
+			ByteBuffer data = config.getEntry(this.getNameFile() + ".dat").getBuffer();
+			ByteBuffer idx = config.getEntry(this.getNameFile() + ".idx").getBuffer();
+
+			int count = idx.getShort(), index = 2;
+			int[] indices = new int[count];
+			for (int i = 0; i < count; i++) {
+				indices[i] = index;
+				index += idx.getShort();
+			}
+
+			this.initDefinition(count, data, indices);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Error decoding Definitions.", e);
+		}
+	}
+
+	/**
+	 * @return the file name of files .dat and .idx
+     */
+	protected abstract String getNameFile();
+
+	protected abstract void initDefinition(int count, ByteBuffer data, int[] indices);
+
+	/**
+	 * Decodes a single definition.
+	 *
+	 * @param id The definition's id.
+	 * @param data The buffer.
+	 * @return The {@link Definition}.
+	 */
+	protected abstract D decode(int id, ByteBuffer data);
+}

--- a/cache/src/main/org/apollo/cache/def/Definition.java
+++ b/cache/src/main/org/apollo/cache/def/Definition.java
@@ -1,0 +1,7 @@
+package org.apollo.cache.def;
+
+/**
+ * @author AymericDu
+ */
+public interface Definition {
+}

--- a/cache/src/main/org/apollo/cache/def/EquipmentDefinition.java
+++ b/cache/src/main/org/apollo/cache/def/EquipmentDefinition.java
@@ -10,7 +10,7 @@ import com.google.common.base.Preconditions;
  *
  * @author Graham
  */
-public final class EquipmentDefinition {
+public final class EquipmentDefinition implements Definition {
 
 	/**
 	 * The attack id.

--- a/cache/src/main/org/apollo/cache/def/ItemDefinition.java
+++ b/cache/src/main/org/apollo/cache/def/ItemDefinition.java
@@ -9,7 +9,7 @@ import com.google.common.collect.HashBiMap;
  *
  * @author Graham
  */
-public final class ItemDefinition {
+public final class ItemDefinition implements Definition {
 
 	/**
 	 * The item definitions.

--- a/cache/src/main/org/apollo/cache/def/NpcDefinition.java
+++ b/cache/src/main/org/apollo/cache/def/NpcDefinition.java
@@ -7,7 +7,7 @@ import com.google.common.base.Preconditions;
  *
  * @author Chris Fletcher
  */
-public final class NpcDefinition {
+public final class NpcDefinition implements Definition {
 
 	/**
 	 * The npc definitions.

--- a/cache/src/main/org/apollo/cache/def/ObjectDefinition.java
+++ b/cache/src/main/org/apollo/cache/def/ObjectDefinition.java
@@ -7,7 +7,7 @@ import com.google.common.base.Preconditions;
  *
  * @author Major
  */
-public final class ObjectDefinition {
+public final class ObjectDefinition implements Definition {
 
 	/**
 	 * The array of game object definitions.


### PR DESCRIPTION
Hello,

I made a "template method" on `DefinitionDecoder`. This modification remove the code duplication between the three classes (`ItemDefinitionDecoder`, `ObjectDefinitionDecoder` and `NpcDefinitionDecoder`).

Thanks.
