### PR TITLE
Add message when encoder is equals to null

### DIFF
--- a/net/src/main/org/apollo/net/codec/game/GameMessageEncoder.java
+++ b/net/src/main/org/apollo/net/codec/game/GameMessageEncoder.java
@@ -36,6 +36,8 @@ public final class GameMessageEncoder extends MessageToMessageEncoder<Message> {
 		MessageEncoder<Message> encoder = (MessageEncoder<Message>) release.getMessageEncoder(message.getClass());
 		if (encoder != null) {
 			out.add(encoder.encode(message));
+		} else {
+			System.out.println("Unidentified message to encode - message: " + message.getClass() + ".");
 		}
 	}
 


### PR DESCRIPTION
Hello,
I saw that decode method print a message when the decoder is null in `GameMessageDecoder`.
So I added a message when our variable encoder is null.
Thanks.