### PR TITLE
Add kotlin to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,10 @@ insert_final_newline = false
 indent_style=tab
 tab_width=4
 
+[*.{kt, kts}]
+indent_style=space
+tab_width=4
+
 [*.rb]
 indent_style=space
 indent_size=2


### PR DESCRIPTION
Uses the [recommended conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#naming-style).