### PR TITLE
Fix numerical attribute encoding

### DIFF
--- a/game/src/main/java/org/apollo/game/model/entity/attr/NumericalAttribute.java
+++ b/game/src/main/java/org/apollo/game/model/entity/attr/NumericalAttribute.java
@@ -30,13 +30,13 @@ public final class NumericalAttribute extends Attribute<Number> {
 
 	@Override
 	public byte[] encode() {
-		long encoded = type == AttributeType.DOUBLE ? Double.doubleToLongBits((double) value) : (long) value;
+		long encoded = type == AttributeType.DOUBLE ? Double.doubleToLongBits(value.doubleValue()) : value.longValue();
 		return Longs.toByteArray(encoded);
 	}
 
 	@Override
 	public String toString() {
-		return type == AttributeType.DOUBLE ? Double.toString((double) value) : Long.toString((long) value);
+		return type == AttributeType.DOUBLE ? Double.toString(value.doubleValue()) : Long.toString(value.longValue());
 	}
 
 }


### PR DESCRIPTION
If the attribute value was an integer, it would throw this exception during encoding:

```
SEVERE: Unable to save player's game.
java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Long
	at org.apollo.game.model.entity.attr.NumericalAttribute.encode(NumericalAttribute.java:33)
	at org.apollo.game.io.player.BinaryPlayerSerializer.savePlayer(BinaryPlayerSerializer.java:219)
	at org.apollo.game.login.PlayerSaverWorker.run(PlayerSaverWorker.java:53)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```