### PR TITLE
Fix teleport command

### DIFF
--- a/game/plugin/cmd/src/teleport-cmd.plugin.kts
+++ b/game/plugin/cmd/src/teleport-cmd.plugin.kts
@@ -75,7 +75,7 @@ on_command("tele", PrivilegeLevel.ADMINISTRATOR)
         }
     }
 
-private val TELEPORT_DESTINATIONS = listOf(
+val TELEPORT_DESTINATIONS = listOf(
     "alkharid" to Position(3292, 3171, 0),
     "ardougne" to Position(2662, 3304, 0),
     "barrows" to Position(3565, 3314, 0),


### PR DESCRIPTION
Teleport command was throwing this exception when a location is specified rather than coordinates:

```
SEVERE: Exception occurred during pulse!
java.lang.NoSuchMethodError: Teleport_cmd_plugin.access$getTELEPORT_DESTINATIONS$p(LTeleport_cmd_plugin;)Ljava/util/List;
	at Teleport_cmd_plugin$2.invoke(teleport-cmd.plugin.kts:29)
	at Teleport_cmd_plugin$2.invoke(teleport-cmd.plugin.kts:7)
	at org.apollo.game.plugin.kotlin.KotlinPlayerHandlerProxyTrait$DefaultImpls.handleProxy(KotlinPluginScript.kt:93)
	at org.apollo.game.plugin.kotlin.KotlinCommandHandler.handleProxy(KotlinPluginScript.kt:158)
	at org.apollo.game.plugin.kotlin.KotlinCommandHandler.handleProxy(KotlinPluginScript.kt:158)
	at org.apollo.game.plugin.kotlin.KotlinCommandHandler.execute(KotlinPluginScript.kt:164)
	at org.apollo.game.command.CommandListener.executePrivileged(CommandListener.java:51)
	at org.apollo.game.command.CommandDispatcher.dispatch(CommandDispatcher.java:39)
	at org.apollo.game.message.handler.CommandMessageHandler.handle(CommandMessageHandler.java:34)
	at org.apollo.game.message.handler.CommandMessageHandler.handle(CommandMessageHandler.java:14)
	at org.apollo.game.message.handler.MessageHandlerChain.notify(MessageHandlerChain.java:57)
	at org.apollo.game.message.handler.MessageHandlerChainSet.notify(MessageHandlerChainSet.java:45)
	at org.apollo.game.session.GameSession.handlePendingMessages(GameSession.java:96)
	at org.apollo.game.service.GameService.pulse(GameService.java:162)
	at org.apollo.game.GamePulseHandler.run(GamePulseHandler.java:37)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```