### PR TITLE
Fix NoSuchMethodError in runecrafting plugin

### DIFF
--- a/game/plugin/skills/runecrafting/src/runecrafting.plugin.kts
+++ b/game/plugin/skills/runecrafting/src/runecrafting.plugin.kts
@@ -2,7 +2,7 @@ import org.apollo.game.message.impl.*
 import org.apollo.game.model.entity.EquipmentConstants
 import org.apollo.game.model.event.impl.LoginEvent
 
-private val changeAltarObjectConfigId = 491
+val changeAltarObjectConfigId = 491
 
 on_player_event { LoginEvent::class }
     .then {


### PR DESCRIPTION
```
java.lang.NoSuchMethodError: Runecrafting_plugin.access$getChangeAltarObjectConfigId$p(LRunecrafting_plugin;)I
	at Runecrafting_plugin$2.invoke(runecrafting.plugin.kts:13)
	at Runecrafting_plugin$2.invoke(runecrafting.plugin.kts:3)
	at org.apollo.game.plugin.kotlin.KotlinPlayerHandlerProxyTrait$DefaultImpls.handleProxy(KotlinPluginScript.kt:92)
	at org.apollo.game.plugin.kotlin.KotlinPlayerEventHandler.handleProxy(KotlinPluginScript.kt:101)
	at org.apollo.game.plugin.kotlin.KotlinPlayerEventHandler.handleProxy(KotlinPluginScript.kt:101)
	at org.apollo.game.plugin.kotlin.KotlinPlayerEventHandler.handle(KotlinPluginScript.kt:107)
	at org.apollo.game.plugin.kotlin.KotlinPlayerEventHandler.handle(KotlinPluginScript.kt:101)
	at org.apollo.game.model.event.EventListenerChain.notify(EventListenerChain.java:52)
	at org.apollo.game.model.event.EventListenerChainSet.notify(EventListenerChainSet.java:27)
	at org.apollo.game.model.World.submit(World.java:336)
	at org.apollo.game.model.entity.Player.sendInitialMessages(Player.java:759)
	at org.apollo.game.service.GameService.finalizePlayerRegistration(GameService.java:128)
	at org.apollo.game.service.GameService.finalizeRegistrations(GameService.java:222)
	at org.apollo.game.service.GameService.pulse(GameService.java:154)
	at org.apollo.game.GamePulseHandler.run(GamePulseHandler.java:37)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```