### PR TITLE
Make following and trading non-primary actions

### DIFF
--- a/data/plugins/player-action/action.rb
+++ b/data/plugins/player-action/action.rb
@@ -20,8 +20,8 @@ end
 
 ATTACK_ACTION = PlayerAction.new(:second, true, 'Attack')
 CHALLENGE_ACTION = PlayerAction.new(:second, true, 'Challenge')
-FOLLOW_ACTION = PlayerAction.new(:fourth, true, 'Follow')
-TRADE_ACTION = PlayerAction.new(:fifth, true, 'Trade with')
+FOLLOW_ACTION = PlayerAction.new(:fourth, false, 'Follow')
+TRADE_ACTION = PlayerAction.new(:fifth, false, 'Trade with')
 
 # Shows multiple context menu action for the specified player
 def show_actions(player, *actions)

--- a/game/plugin/entity/actions/src/PlayerActionType.kt
+++ b/game/plugin/entity/actions/src/PlayerActionType.kt
@@ -3,6 +3,6 @@ package org.apollo.game.plugin.entity.actions
 enum class PlayerActionType(val displayName: String, val slot: Int, val primary: Boolean = true) {
     ATTACK("Attack", 2),
     CHALLENGE("Challenge", 2),
-    FOLLOW("Follow", 4),
-    TRADE("Trade with", 5)
+    FOLLOW("Follow", 4, false),
+    TRADE("Trade with", 5, false)
 }


### PR DESCRIPTION
This PR makes "Follow" and "Trade with" appear **below** "Walk here" instead of being left click primary actions.